### PR TITLE
Fix prepareDocsForSolr helper

### DIFF
--- a/etl/etllib.py
+++ b/etl/etllib.py
@@ -122,15 +122,7 @@ def prepareDocForSolr(jsondata, unmarshall=True):
 
 def prepareDocsForSolr(jsondata, unmarshall=True):
     jsondocs = json.loads(jsondata) if unmarshall else jsondata
-    docs = []
-    for doc in jsondocs:
-        if "boost" in doc:
-            boost = doc["boost"]
-        else:
-            boost = 1.0
-        docs.append({"add": {"boost": boost, "doc": doc}})
-
-    return json.dumps(docs)
+    return json.dumps(jsondocs)
 
 def _createOrAppendToList(doc, key, val):
     if key in doc:


### PR DESCRIPTION
- prepareDocsForSolr now takes a list of documents to add to Solr and
  formats them into a valid JSON string for addition.
