### PR TITLE
Fix crash bug

### DIFF
--- a/etl/tsvtojson.py
+++ b/etl/tsvtojson.py
@@ -142,7 +142,7 @@ def main(argv=None):
                 if diff > 0:
                     verboseLog("Column Headers and Row Values Don't Match up: numCols: ["+str(len(cols))+"]: numRowValues: ["+str(len(line))+"]")
         
-                for num in range(0, len(cols)):
+                for num in range(0, min(len(cols), len(line))):
                     if ":" in cols[num] and diff > 0:
                         diff = diff - 1
                         continue                    


### PR DESCRIPTION
When a line has less columns than column header, the old version crashes.
