### PR TITLE
added check to ensure conversion happens when encoding is not specified

### DIFF
--- a/etl/etllib.py
+++ b/etl/etllib.py
@@ -83,7 +83,7 @@ def cleanseBody(theDoc):
 
 def readEncodedVal(line, colnum, encodings=None):
     val = None
-    if encodings != None:
+    if encodings != None and len(encodings) > 0:
         for encoding in encodings:
             try:
                 val = line[colnum].decode(encoding).encode("utf-8")


### PR DESCRIPTION
When encodings are not specified, the file in tsvtojson.py has encodings set to an empty list ([]). 
Now in etllib.py checks only if encodings is not None. It passes this check and fails to go through the for loop and hence ends up extracting nothing from the tsv.