### PR TITLE
For local varible 'val' referenced before assignment problems

### DIFF
--- a/etl/etllib.py
+++ b/etl/etllib.py
@@ -99,17 +99,18 @@ def readEncodedVal(line, colnum, encodings=None):
 
 
 def convertToUTF8(src):
+    global val2
     try:
         encoding = _theMagic.from_buffer(src)
-        val = src.decode(encoding).encode("utf-8")
+        val2 = src.decode(encoding).encode("utf-8")
     except magic.MagicException, err:
-        verboseLog("Error detecting encoding for row val: ["+src+"]: Message: "+str(err))
-        val = src
+        verboseLog("Error detecting encoding for row val2: ["+src+"]: Message: "+str(err))
+        val2 = src
     except LookupError, err:
         verboseLog("unknown encoding: binary:"+src+":Message:"+str(err))
-        val = src
+        val2 = src
     finally:
-        return val
+        return val2
 
 def unravelStructs(theDoc):
     if "countries" in theDoc:


### PR DESCRIPTION
Hi Chris:
For this problem,we just need change 'val' in the convertToUTF8 function. For this problem, when we use global varibles in Python we can solve it and run it out. 

An easy example for this problem:
```
val=9
def test(flag):  
    if flag:  
        val = 1  
    else:  
        print 'Error'  
    return val 
```
it will have error:local varible 'val' referenced before assignment problems
When we change the code into followings:
```
val=9
def test(flag):
    global val
    if flag: 
        val = 1 
    else: 
        print 'test' 
    return val
```
the problem will be solved